### PR TITLE
Optional start time and dynamic rate calculation

### DIFF
--- a/contracts/zones/TokenLockupPlansHandler.sol
+++ b/contracts/zones/TokenLockupPlansHandler.sol
@@ -52,7 +52,7 @@ contract TokenLockupPlansHandler is ITokenLockupPlansHandler {
         );
 
         // create time locks for each if specified
-        if (lockParams.considerationLockupParams.start != 0) {
+        if (lockParams.considerationLockupParams.initialized) {
             if (zoneParameters.consideration.length < 1) {
                 revert NO_CONSIDERATION();
             }
@@ -69,7 +69,7 @@ contract TokenLockupPlansHandler is ITokenLockupPlansHandler {
                 lockParams.considerationLockupParams
             );
         }
-        if (lockParams.offerLockupParams.start != 0) {
+        if (lockParams.offerLockupParams.initialized) {
             if (zoneParameters.offer.length < 1) {
                 revert NO_OFFER();
             }

--- a/contracts/zones/TokenLockupPlansHandler.sol
+++ b/contracts/zones/TokenLockupPlansHandler.sol
@@ -115,13 +115,18 @@ contract TokenLockupPlansHandler is ITokenLockupPlansHandler {
         // approve tokenLockupPlans contract to spend this token
         IERC20(token).approve(address(tokenLockupPlans), amount);
 
+        // if user didn't specify start time, use block.timestamp
+        if (createPlanParams.start == 0) {
+            createPlanParams.start = block.timestamp;
+        }
+
         // create lockup
         tokenLockupPlans.createPlan(
             recipient,
             token,
             amount,
             createPlanParams.start,
-            createPlanParams.cliff,
+            createPlanParams.start + createPlanParams.cliffOffsetTime,
             createPlanParams.rate,
             createPlanParams.period
         );

--- a/contracts/zones/TokenLockupPlansHandler.sol
+++ b/contracts/zones/TokenLockupPlansHandler.sol
@@ -120,6 +120,20 @@ contract TokenLockupPlansHandler is ITokenLockupPlansHandler {
             createPlanParams.start = block.timestamp;
         }
 
+        // end offset should be greater than cliff offset
+        if (createPlanParams.endOffsetTime < createPlanParams.cliffOffsetTime) {
+            revert END_LESS_THAN_CLIFF();
+        }
+
+        // calculate rate
+        uint256 rate = (amount * createPlanParams.period) /
+            createPlanParams.endOffsetTime;
+
+        // check for underflow
+        if (rate == 0) {
+            revert INVALID_RATE();
+        }
+
         // create lockup
         tokenLockupPlans.createPlan(
             recipient,
@@ -127,7 +141,7 @@ contract TokenLockupPlansHandler is ITokenLockupPlansHandler {
             amount,
             createPlanParams.start,
             createPlanParams.start + createPlanParams.cliffOffsetTime,
-            createPlanParams.rate,
+            rate,
             createPlanParams.period
         );
     }

--- a/contracts/zones/interfaces/ITokenLockupPlansHandler.sol
+++ b/contracts/zones/interfaces/ITokenLockupPlansHandler.sol
@@ -16,6 +16,7 @@ interface ITokenLockupPlansHandler is ZoneInterface {
         uint256 cliff;
         uint256 rate;
         uint256 period;
+        bool initialized;
     }
 
     struct LockParams {

--- a/contracts/zones/interfaces/ITokenLockupPlansHandler.sol
+++ b/contracts/zones/interfaces/ITokenLockupPlansHandler.sol
@@ -10,11 +10,19 @@ interface ITokenLockupPlansHandler is ZoneInterface {
     error OFFER_NOT_ERC20();
     error CONSIDERATION_NOT_ERC20();
     error CALLER_NOT_SEAPORT();
+    error END_LESS_THAN_CLIFF();
+    error INVALID_RATE();
 
+    /**
+     * @param start when the vesting plan starts, a unix timestamp
+     * @param cliffOffsetTime number of seconds after start, when the cliff begins
+     * @param endOffsetTime number of seconds after start, when the plan is fully vested
+     * @param period how frequently tokens will vest after the cliff (e.g. 100 = every 100 seconds)
+     */
     struct CreatePlanParams {
         uint256 start;
         uint256 cliffOffsetTime;
-        uint256 rate;
+        uint256 endOffsetTime;
         uint256 period;
         bool initialized;
     }

--- a/contracts/zones/interfaces/ITokenLockupPlansHandler.sol
+++ b/contracts/zones/interfaces/ITokenLockupPlansHandler.sol
@@ -13,7 +13,7 @@ interface ITokenLockupPlansHandler is ZoneInterface {
 
     struct CreatePlanParams {
         uint256 start;
-        uint256 cliff;
+        uint256 cliffOffsetTime;
         uint256 rate;
         uint256 period;
         bool initialized;

--- a/test/TokenLockupPlansHandler.spec.ts
+++ b/test/TokenLockupPlansHandler.spec.ts
@@ -92,6 +92,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
               {
@@ -102,6 +103,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
             ],
@@ -114,12 +116,14 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: timestamp + 1000n,
               rate: 1000n,
               period: 1n,
+              initialized: true,
             },
             considerationLockupParams: {
               start: timestamp + 500n,
               cliff: timestamp + 1000n,
               rate: 1000n,
               period: 1n,
+              initialized: true,
             },
           },
         ]
@@ -293,6 +297,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
               {
@@ -303,6 +308,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
             ],
@@ -315,6 +321,7 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: timestamp + 1000n,
               rate: 1000n,
               period: 1n,
+              initialized: true,
             },
             // set everything to 0
             considerationLockupParams: {
@@ -322,6 +329,7 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: 0n,
               rate: 0n,
               period: 0n,
+              initialized: false,
             },
           },
         ]
@@ -487,6 +495,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
               {
@@ -497,6 +506,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
             ],
@@ -509,6 +519,7 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: timestamp + 1000n,
               rate: 1000n,
               period: 1n,
+              initialized: true,
             },
             // set everything to 0
             offerLockupParams: {
@@ -516,6 +527,7 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: 0n,
               rate: 0n,
               period: 0n,
+              initialized: false,
             },
           },
         ]
@@ -688,6 +700,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
               {
@@ -698,6 +711,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
             ],
@@ -710,12 +724,14 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: timestamp + cliff,
               rate: usdcRate,
               period: 1n,
+              initialized: true,
             },
             considerationLockupParams: {
               start: timestamp,
               cliff: timestamp + cliff,
               rate: wethRate,
               period: 1n,
+              initialized: true,
             },
           },
         ]
@@ -917,6 +933,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
             ],
@@ -929,6 +946,7 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: timestamp + 1000n,
               rate: 1000n,
               period: 1n,
+              initialized: true,
             },
           },
         ]
@@ -974,6 +992,7 @@ describe("TokenLockupPlansHandler tests", function () {
                   { name: "cliff", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
                 ],
               },
             ],
@@ -986,6 +1005,7 @@ describe("TokenLockupPlansHandler tests", function () {
               cliff: timestamp + 1000n,
               rate: 1000n,
               period: 1n,
+              initialized: true,
             },
           },
         ]

--- a/test/TokenLockupPlansHandler.spec.ts
+++ b/test/TokenLockupPlansHandler.spec.ts
@@ -90,7 +90,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -101,7 +101,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -114,14 +114,14 @@ describe("TokenLockupPlansHandler tests", function () {
             offerLockupParams: {
               start: timestamp + 500n,
               cliffOffsetTime: 500n,
-              rate: 1000n,
+              endOffsetTime: 1000n,
               period: 1n,
               initialized: true,
             },
             considerationLockupParams: {
               start: timestamp + 500n,
               cliffOffsetTime: 500n,
-              rate: 1000n,
+              endOffsetTime: 1000n,
               period: 1n,
               initialized: true,
             },
@@ -295,7 +295,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -306,7 +306,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -319,7 +319,7 @@ describe("TokenLockupPlansHandler tests", function () {
             offerLockupParams: {
               start: timestamp + 500n,
               cliffOffsetTime: 500n,
-              rate: 1000n,
+              endOffsetTime: 1000n,
               period: 1n,
               initialized: true,
             },
@@ -327,7 +327,7 @@ describe("TokenLockupPlansHandler tests", function () {
             considerationLockupParams: {
               start: 0n,
               cliffOffsetTime: 0n,
-              rate: 0n,
+              endOffsetTime: 0n,
               period: 0n,
               initialized: false,
             },
@@ -493,7 +493,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -504,7 +504,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -517,7 +517,7 @@ describe("TokenLockupPlansHandler tests", function () {
             considerationLockupParams: {
               start: timestamp + 500n,
               cliffOffsetTime: 500n,
-              rate: 1000n,
+              endOffsetTime: 1000n,
               period: 1n,
               initialized: true,
             },
@@ -525,7 +525,7 @@ describe("TokenLockupPlansHandler tests", function () {
             offerLockupParams: {
               start: 0n,
               cliffOffsetTime: 0n,
-              rate: 0n,
+              endOffsetTime: 0n,
               period: 0n,
               initialized: false,
             },
@@ -683,8 +683,9 @@ describe("TokenLockupPlansHandler tests", function () {
 
       // construct order
       const salt = generateSalt();
-      const usdcRate = usdcTradeAmount / 1000n;
-      const wethRate = wethTradeamount / 1000n;
+      const endOffset = 1000n;
+      const usdcRate = usdcTradeAmount / endOffset;
+      const wethRate = wethTradeamount / endOffset;
       const cliff = 100n;
       const encodedLockParams = encodeAbiParameters(
         [
@@ -698,7 +699,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -709,7 +710,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -722,14 +723,14 @@ describe("TokenLockupPlansHandler tests", function () {
             offerLockupParams: {
               start: timestamp,
               cliffOffsetTime: cliff,
-              rate: usdcRate,
+              endOffsetTime: endOffset,
               period: 1n,
               initialized: true,
             },
             considerationLockupParams: {
               start: timestamp,
               cliffOffsetTime: cliff,
-              rate: wethRate,
+              endOffsetTime: endOffset,
               period: 1n,
               initialized: true,
             },
@@ -876,10 +877,10 @@ describe("TokenLockupPlansHandler tests", function () {
       ).to.greaterThan(Number(usdcRate * cliff));
       expect(
         Number(await weth.read.balanceOf([alice.account.address]))
-      ).to.lessThan(Number(wethTradeamount));
+      ).to.lessThan(Number(wethRate * cliff) * 1.1);
       expect(
         Number(await usdc.read.balanceOf([bob.account.address]))
-      ).to.lessThan(Number(usdcTradeAmount));
+      ).to.lessThan(Number(usdcRate * cliff) * 1.1);
 
       // go forward in time so the full amount is vested
       await time.increase(1000);
@@ -900,8 +901,14 @@ describe("TokenLockupPlansHandler tests", function () {
     });
 
     it("try to lock order with no offer and/or consideration", async function () {
-      const { bob, weth, getWeth, startingWethBalance, lockupHandler } =
+      const { alice, bob, weth, getWeth, startingWethBalance, lockup } =
         await loadFixture(fixture);
+
+      // custom lockupHandler so we can call validateOrder directlry
+      const lockupHandler = await hre.viem.deployContract(
+        "TokenLockupPlansHandler",
+        [lockup.address, alice.account.address]
+      );
 
       // amounts
       const timestamp = await getBlockTimestamp();
@@ -926,12 +933,23 @@ describe("TokenLockupPlansHandler tests", function () {
             type: "tuple",
             components: [
               {
+                name: "offerLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+              {
                 name: "considerationLockupParams",
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -944,9 +962,17 @@ describe("TokenLockupPlansHandler tests", function () {
             considerationLockupParams: {
               start: timestamp + 500n,
               cliffOffsetTime: 500n,
-              rate: 1000n,
+              endOffsetTime: 1000n,
               period: 1n,
               initialized: true,
+            },
+            // set everything to 0
+            offerLockupParams: {
+              start: 0n,
+              cliffOffsetTime: 0n,
+              endOffsetTime: 0n,
+              period: 0n,
+              initialized: false,
             },
           },
         ]
@@ -973,7 +999,7 @@ describe("TokenLockupPlansHandler tests", function () {
         endTime: 0n,
         zoneHash: hashedLockParamsNoConsideration,
       };
-      expect(
+      await expect(
         lockupHandler.write.validateOrder([zoneParamsNoConsideration])
       ).to.be.rejectedWith("NO_CONSIDERATION");
 
@@ -990,7 +1016,18 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+              {
+                name: "considerationLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -1003,9 +1040,17 @@ describe("TokenLockupPlansHandler tests", function () {
             offerLockupParams: {
               start: timestamp + 500n,
               cliffOffsetTime: 500n,
-              rate: 1000n,
+              endOffsetTime: 1000n,
               period: 1n,
               initialized: true,
+            },
+            // set everything to 0
+            considerationLockupParams: {
+              start: 0n,
+              cliffOffsetTime: 0n,
+              endOffsetTime: 0n,
+              period: 0n,
+              initialized: false,
             },
           },
         ]
@@ -1015,22 +1060,23 @@ describe("TokenLockupPlansHandler tests", function () {
         orderHash: zeroHash,
         fulfiller: bob.account.address,
         offerer: zeroAddress,
-        offer: [
+        offer: [],
+        consideration: [
           {
             itemType: 1, // erc20
             token: weth.address,
             identifier: 0n,
             amount: wethTradeamount,
+            recipient: alice.account.address,
           },
         ],
-        consideration: [],
         extraData: encodedLockParamsNoOffer,
         orderHashes: [],
         startTime: 0n,
         endTime: 0n,
         zoneHash: hashedLockParamsNoOffer,
       };
-      expect(
+      await expect(
         lockupHandler.write.validateOrder([zoneParamsNoOffer])
       ).to.be.rejectedWith("NO_OFFER");
     });
@@ -1053,7 +1099,7 @@ describe("TokenLockupPlansHandler tests", function () {
       };
 
       // try calling validateOrder directly
-      expect(
+      await expect(
         lockupHandler.write.validateOrder([fakeZoneParams])
       ).to.be.rejectedWith("CALLER_NOT_SEAPORT");
     });
@@ -1100,8 +1146,9 @@ describe("TokenLockupPlansHandler tests", function () {
 
       // construct order
       const salt = generateSalt();
-      const usdcRate = usdcTradeAmount / 1000n;
-      const wethRate = wethTradeamount / 1000n;
+      const endTime = 1000n;
+      const usdcRate = usdcTradeAmount / endTime;
+      const wethRate = wethTradeamount / endTime;
       const cliff = 100n;
       const encodedLockParams = encodeAbiParameters(
         [
@@ -1115,7 +1162,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -1126,7 +1173,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 components: [
                   { name: "start", type: "uint256" },
                   { name: "cliffOffsetTime", type: "uint256" },
-                  { name: "rate", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
                 ],
@@ -1139,14 +1186,14 @@ describe("TokenLockupPlansHandler tests", function () {
             offerLockupParams: {
               start: 0n, // use block.timestamp
               cliffOffsetTime: cliff,
-              rate: usdcRate,
+              endOffsetTime: endTime,
               period: 1n,
               initialized: true,
             },
             considerationLockupParams: {
               start: 0n, // use block.timestamp
               cliffOffsetTime: cliff,
-              rate: wethRate,
+              endOffsetTime: endTime,
               period: 1n,
               initialized: true,
             },
@@ -1298,10 +1345,10 @@ describe("TokenLockupPlansHandler tests", function () {
       ).to.greaterThan(Number(usdcRate * cliff));
       expect(
         Number(await weth.read.balanceOf([alice.account.address]))
-      ).to.lessThan(Number(wethTradeamount));
+      ).to.lessThan(Number(wethRate * cliff) * 1.1);
       expect(
         Number(await usdc.read.balanceOf([bob.account.address]))
-      ).to.lessThan(Number(usdcTradeAmount));
+      ).to.lessThan(Number(usdcRate * cliff) * 1.1);
 
       // go forward in time so the full amount is vested
       await time.increase(1000);
@@ -1319,6 +1366,386 @@ describe("TokenLockupPlansHandler tests", function () {
         usdcTradeAmount
       );
       expect(await weth.read.balanceOf([bob.account.address])).to.eq(0n);
+    });
+
+    it("end less than cliff should revert", async function () {
+      const {
+        alice,
+        bob,
+        seaport,
+        usdc,
+        weth,
+        getSeaport,
+        getUsdc,
+        getWeth,
+        aliceStartingUsdcBalance,
+        startingWethBalance,
+        lockupHandler,
+        lockup,
+      } = await loadFixture(fixture);
+
+      // amounts
+      const timestamp = await getBlockTimestamp();
+      const usdcTradeAmount = parseUnits("1000", 6);
+      const wethTradeamount = parseUnits("1", 18);
+
+      // alice will designate that only bob can fill the trade
+      // alice and bob approve seaport contract
+      await (
+        await getUsdc(alice)
+      ).write.approve([seaportAddress, usdcTradeAmount]);
+      await (
+        await getWeth(bob)
+      ).write.approve([seaportAddress, wethTradeamount]);
+
+      // alice and bob also have to approve the lockup handler for the opposite token
+      // bc lockups are created atomically post-trade
+      await (
+        await getWeth(alice)
+      ).write.approve([lockupHandler.address, wethTradeamount]);
+      await (
+        await getUsdc(bob)
+      ).write.approve([lockupHandler.address, usdcTradeAmount]);
+
+      // construct order
+      const salt = generateSalt();
+      const encodedLockParams = encodeAbiParameters(
+        [
+          {
+            name: "LockParams",
+            type: "tuple",
+            components: [
+              {
+                name: "offerLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+              {
+                name: "considerationLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+            ],
+          },
+        ],
+        [
+          {
+            offerLockupParams: {
+              start: timestamp + 500n,
+              cliffOffsetTime: 2000n, // cliff greater than end
+              endOffsetTime: 1000n,
+              period: 1n,
+              initialized: true,
+            },
+            // set everything to 0
+            considerationLockupParams: {
+              start: 0n,
+              cliffOffsetTime: 0n,
+              endOffsetTime: 0n,
+              period: 0n,
+              initialized: false,
+            },
+          },
+        ]
+      );
+      const hashedLockParams = keccak256(encodedLockParams);
+      const baseOrderParameters = {
+        offerer: alice.account.address,
+        zone: lockupHandler.address, // don't forget this
+
+        // this is what the trader is giving
+        offer: [
+          {
+            itemType: 1, // 1 == erc20
+            token: usdc.address,
+            identifierOrCriteria: 0n, // criteria not used for erc20s
+            startAmount: usdcTradeAmount,
+            endAmount: usdcTradeAmount,
+          },
+        ],
+
+        // what the trader expects to receive
+        consideration: [
+          {
+            itemType: 1,
+            token: weth.address,
+            identifierOrCriteria: 0n,
+            startAmount: wethTradeamount,
+            endAmount: wethTradeamount,
+            recipient: alice.account.address,
+          },
+        ],
+        orderType: 2, // full restricted
+        startTime: timestamp,
+        endTime: timestamp + 86400n, // 24 hours from now
+        zoneHash: hashedLockParams,
+        salt: salt,
+        conduitKey: zeroHash, // not using a conduit
+      };
+      const orderParameters = {
+        ...baseOrderParameters,
+        totalOriginalConsiderationItems: 1n,
+      };
+
+      // get contract info
+      const info = await seaport.read.information();
+      const version = info[0];
+      const name = await seaport.read.name();
+      const domainData = {
+        name: name,
+        version: version,
+
+        // although we are forking eth mainnet, hardhat uses this chainId instead of the actual chainId (in this case, 1)
+        chainId: 31337,
+        verifyingContract: seaportAddress,
+      };
+      const counter = await seaport.read.getCounter([alice.account.address]);
+      const orderComponents = {
+        ...baseOrderParameters,
+        counter: counter,
+      };
+
+      // alice signs the order
+      const signature = await alice.signTypedData({
+        domain: domainData,
+        types: orderType,
+        primaryType: "OrderComponents",
+        message: orderComponents,
+      });
+
+      // construct advanced order
+      const advancedOrder = {
+        parameters: orderParameters,
+        numerator: wethTradeamount,
+        denominator: wethTradeamount,
+        signature: signature,
+        extraData: encodedLockParams,
+      };
+
+      // check that bob can swap
+      // check for expected starting balances
+      expect(await usdc.read.balanceOf([alice.account.address])).to.eq(
+        aliceStartingUsdcBalance
+      );
+      expect(await weth.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await weth.read.balanceOf([bob.account.address])).to.eq(
+        startingWethBalance
+      );
+      expect(await usdc.read.balanceOf([bob.account.address])).to.eq(0n);
+
+      // revert
+      await expect(
+        (
+          await getSeaport(bob)
+        ).write.fulfillAdvancedOrder([
+          advancedOrder,
+          [],
+          zeroHash,
+          bob.account.address,
+        ])
+      ).to.be.rejectedWith("END_LESS_THAN_CLIFF");
+    });
+
+    it("invalid rate should revert", async function () {
+      const {
+        alice,
+        bob,
+        seaport,
+        usdc,
+        weth,
+        getSeaport,
+        getUsdc,
+        getWeth,
+        aliceStartingUsdcBalance,
+        startingWethBalance,
+        lockupHandler,
+        lockup,
+      } = await loadFixture(fixture);
+
+      // amounts
+      const timestamp = await getBlockTimestamp();
+      const usdcTradeAmount = parseUnits("1000", 6);
+      const wethTradeamount = parseUnits("1", 18);
+
+      // alice will designate that only bob can fill the trade
+      // alice and bob approve seaport contract
+      await (
+        await getUsdc(alice)
+      ).write.approve([seaportAddress, usdcTradeAmount]);
+      await (
+        await getWeth(bob)
+      ).write.approve([seaportAddress, wethTradeamount]);
+
+      // alice and bob also have to approve the lockup handler for the opposite token
+      // bc lockups are created atomically post-trade
+      await (
+        await getWeth(alice)
+      ).write.approve([lockupHandler.address, wethTradeamount]);
+      await (
+        await getUsdc(bob)
+      ).write.approve([lockupHandler.address, usdcTradeAmount]);
+
+      // construct order
+      const salt = generateSalt();
+      const encodedLockParams = encodeAbiParameters(
+        [
+          {
+            name: "LockParams",
+            type: "tuple",
+            components: [
+              {
+                name: "offerLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+              {
+                name: "considerationLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "endOffsetTime", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+            ],
+          },
+        ],
+        [
+          {
+            offerLockupParams: {
+              start: timestamp + 500n,
+              cliffOffsetTime: 500n,
+              endOffsetTime: 100000000000000000n, // we want rate calc to underflow
+              period: 1n,
+              initialized: true,
+            },
+            // set everything to 0
+            considerationLockupParams: {
+              start: 0n,
+              cliffOffsetTime: 0n,
+              endOffsetTime: 0n,
+              period: 0n,
+              initialized: false,
+            },
+          },
+        ]
+      );
+      const hashedLockParams = keccak256(encodedLockParams);
+      const baseOrderParameters = {
+        offerer: alice.account.address,
+        zone: lockupHandler.address, // don't forget this
+
+        // this is what the trader is giving
+        offer: [
+          {
+            itemType: 1, // 1 == erc20
+            token: usdc.address,
+            identifierOrCriteria: 0n, // criteria not used for erc20s
+            startAmount: usdcTradeAmount,
+            endAmount: usdcTradeAmount,
+          },
+        ],
+
+        // what the trader expects to receive
+        consideration: [
+          {
+            itemType: 1,
+            token: weth.address,
+            identifierOrCriteria: 0n,
+            startAmount: wethTradeamount,
+            endAmount: wethTradeamount,
+            recipient: alice.account.address,
+          },
+        ],
+        orderType: 2, // full restricted
+        startTime: timestamp,
+        endTime: timestamp + 86400n, // 24 hours from now
+        zoneHash: hashedLockParams,
+        salt: salt,
+        conduitKey: zeroHash, // not using a conduit
+      };
+      const orderParameters = {
+        ...baseOrderParameters,
+        totalOriginalConsiderationItems: 1n,
+      };
+
+      // get contract info
+      const info = await seaport.read.information();
+      const version = info[0];
+      const name = await seaport.read.name();
+      const domainData = {
+        name: name,
+        version: version,
+
+        // although we are forking eth mainnet, hardhat uses this chainId instead of the actual chainId (in this case, 1)
+        chainId: 31337,
+        verifyingContract: seaportAddress,
+      };
+      const counter = await seaport.read.getCounter([alice.account.address]);
+      const orderComponents = {
+        ...baseOrderParameters,
+        counter: counter,
+      };
+
+      // alice signs the order
+      const signature = await alice.signTypedData({
+        domain: domainData,
+        types: orderType,
+        primaryType: "OrderComponents",
+        message: orderComponents,
+      });
+
+      // construct advanced order
+      const advancedOrder = {
+        parameters: orderParameters,
+        numerator: wethTradeamount,
+        denominator: wethTradeamount,
+        signature: signature,
+        extraData: encodedLockParams,
+      };
+
+      // check that bob can swap
+      // check for expected starting balances
+      expect(await usdc.read.balanceOf([alice.account.address])).to.eq(
+        aliceStartingUsdcBalance
+      );
+      expect(await weth.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await weth.read.balanceOf([bob.account.address])).to.eq(
+        startingWethBalance
+      );
+      expect(await usdc.read.balanceOf([bob.account.address])).to.eq(0n);
+
+      // revert
+      await expect(
+        (
+          await getSeaport(bob)
+        ).write.fulfillAdvancedOrder([
+          advancedOrder,
+          [],
+          zeroHash,
+          bob.account.address,
+        ])
+      ).to.be.rejectedWith("INVALID_RATE");
     });
   });
 });

--- a/test/TokenLockupPlansHandler.spec.ts
+++ b/test/TokenLockupPlansHandler.spec.ts
@@ -89,7 +89,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -100,7 +100,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -113,14 +113,14 @@ describe("TokenLockupPlansHandler tests", function () {
           {
             offerLockupParams: {
               start: timestamp + 500n,
-              cliff: timestamp + 1000n,
+              cliffOffsetTime: 500n,
               rate: 1000n,
               period: 1n,
               initialized: true,
             },
             considerationLockupParams: {
               start: timestamp + 500n,
-              cliff: timestamp + 1000n,
+              cliffOffsetTime: 500n,
               rate: 1000n,
               period: 1n,
               initialized: true,
@@ -294,7 +294,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -305,7 +305,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -318,7 +318,7 @@ describe("TokenLockupPlansHandler tests", function () {
           {
             offerLockupParams: {
               start: timestamp + 500n,
-              cliff: timestamp + 1000n,
+              cliffOffsetTime: 500n,
               rate: 1000n,
               period: 1n,
               initialized: true,
@@ -326,7 +326,7 @@ describe("TokenLockupPlansHandler tests", function () {
             // set everything to 0
             considerationLockupParams: {
               start: 0n,
-              cliff: 0n,
+              cliffOffsetTime: 0n,
               rate: 0n,
               period: 0n,
               initialized: false,
@@ -492,7 +492,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -503,7 +503,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -516,7 +516,7 @@ describe("TokenLockupPlansHandler tests", function () {
           {
             considerationLockupParams: {
               start: timestamp + 500n,
-              cliff: timestamp + 1000n,
+              cliffOffsetTime: 500n,
               rate: 1000n,
               period: 1n,
               initialized: true,
@@ -524,7 +524,7 @@ describe("TokenLockupPlansHandler tests", function () {
             // set everything to 0
             offerLockupParams: {
               start: 0n,
-              cliff: 0n,
+              cliffOffsetTime: 0n,
               rate: 0n,
               period: 0n,
               initialized: false,
@@ -697,7 +697,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -708,7 +708,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -721,14 +721,14 @@ describe("TokenLockupPlansHandler tests", function () {
           {
             offerLockupParams: {
               start: timestamp,
-              cliff: timestamp + cliff,
+              cliffOffsetTime: cliff,
               rate: usdcRate,
               period: 1n,
               initialized: true,
             },
             considerationLockupParams: {
               start: timestamp,
-              cliff: timestamp + cliff,
+              cliffOffsetTime: cliff,
               rate: wethRate,
               period: 1n,
               initialized: true,
@@ -930,7 +930,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -943,7 +943,7 @@ describe("TokenLockupPlansHandler tests", function () {
           {
             considerationLockupParams: {
               start: timestamp + 500n,
-              cliff: timestamp + 1000n,
+              cliffOffsetTime: 500n,
               rate: 1000n,
               period: 1n,
               initialized: true,
@@ -989,7 +989,7 @@ describe("TokenLockupPlansHandler tests", function () {
                 type: "tuple",
                 components: [
                   { name: "start", type: "uint256" },
-                  { name: "cliff", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
                   { name: "rate", type: "uint256" },
                   { name: "period", type: "uint256" },
                   { name: "initialized", type: "bool" },
@@ -1002,7 +1002,7 @@ describe("TokenLockupPlansHandler tests", function () {
           {
             offerLockupParams: {
               start: timestamp + 500n,
-              cliff: timestamp + 1000n,
+              cliffOffsetTime: 500n,
               rate: 1000n,
               period: 1n,
               initialized: true,
@@ -1056,6 +1056,269 @@ describe("TokenLockupPlansHandler tests", function () {
       expect(
         lockupHandler.write.validateOrder([fakeZoneParams])
       ).to.be.rejectedWith("CALLER_NOT_SEAPORT");
+    });
+
+    it("user doesn't provide start time (expected to use block.timestamp)", async function () {
+      const {
+        alice,
+        bob,
+        seaport,
+        usdc,
+        weth,
+        getSeaport,
+        getUsdc,
+        getWeth,
+        aliceStartingUsdcBalance,
+        startingWethBalance,
+        lockupHandler,
+        lockup,
+        getLockup,
+      } = await loadFixture(fixture);
+
+      // amounts
+      const timestamp = await getBlockTimestamp();
+      const usdcTradeAmount = parseUnits("1000", 6);
+      const wethTradeamount = parseUnits("1", 18);
+
+      // alice will designate that only bob can fill the trade
+      // alice and bob approve seaport contract
+      await (
+        await getUsdc(alice)
+      ).write.approve([seaportAddress, usdcTradeAmount]);
+      await (
+        await getWeth(bob)
+      ).write.approve([seaportAddress, wethTradeamount]);
+
+      // alice and bob also have to approve the time lock handler for the opposite token
+      // bc time locks are created atomically post-trade
+      await (
+        await getWeth(alice)
+      ).write.approve([lockupHandler.address, wethTradeamount]);
+      await (
+        await getUsdc(bob)
+      ).write.approve([lockupHandler.address, usdcTradeAmount]);
+
+      // construct order
+      const salt = generateSalt();
+      const usdcRate = usdcTradeAmount / 1000n;
+      const wethRate = wethTradeamount / 1000n;
+      const cliff = 100n;
+      const encodedLockParams = encodeAbiParameters(
+        [
+          {
+            name: "LockParams",
+            type: "tuple",
+            components: [
+              {
+                name: "offerLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "rate", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+              {
+                name: "considerationLockupParams",
+                type: "tuple",
+                components: [
+                  { name: "start", type: "uint256" },
+                  { name: "cliffOffsetTime", type: "uint256" },
+                  { name: "rate", type: "uint256" },
+                  { name: "period", type: "uint256" },
+                  { name: "initialized", type: "bool" },
+                ],
+              },
+            ],
+          },
+        ],
+        [
+          {
+            offerLockupParams: {
+              start: 0n, // use block.timestamp
+              cliffOffsetTime: cliff,
+              rate: usdcRate,
+              period: 1n,
+              initialized: true,
+            },
+            considerationLockupParams: {
+              start: 0n, // use block.timestamp
+              cliffOffsetTime: cliff,
+              rate: wethRate,
+              period: 1n,
+              initialized: true,
+            },
+          },
+        ]
+      );
+      const hashedLockParams = keccak256(encodedLockParams);
+      const baseOrderParameters = {
+        offerer: alice.account.address,
+        zone: lockupHandler.address, // don't forget this
+
+        // this is what the trader is giving
+        offer: [
+          {
+            itemType: 1, // 1 == erc20
+            token: usdc.address,
+            identifierOrCriteria: 0n, // criteria not used for erc20s
+            startAmount: usdcTradeAmount,
+            endAmount: usdcTradeAmount,
+          },
+        ],
+
+        // what the trader expects to receive
+        consideration: [
+          {
+            itemType: 1,
+            token: weth.address,
+            identifierOrCriteria: 0n,
+            startAmount: wethTradeamount,
+            endAmount: wethTradeamount,
+            recipient: alice.account.address,
+          },
+        ],
+        orderType: 2, // full restricted
+        startTime: timestamp,
+        endTime: timestamp + 86400n, // 24 hours from now
+        zoneHash: hashedLockParams,
+        salt: salt,
+        conduitKey: zeroHash, // not using a conduit
+      };
+      const orderParameters = {
+        ...baseOrderParameters,
+        totalOriginalConsiderationItems: 1n,
+      };
+
+      // get contract info
+      const info = await seaport.read.information();
+      const version = info[0];
+      const name = await seaport.read.name();
+      const domainData = {
+        name: name,
+        version: version,
+
+        // although we are forking eth mainnet, hardhat uses this chainId instead of the actual chainId (in this case, 1)
+        chainId: 31337,
+        verifyingContract: seaportAddress,
+      };
+      const counter = await seaport.read.getCounter([alice.account.address]);
+      const orderComponents = {
+        ...baseOrderParameters,
+        counter: counter,
+      };
+
+      // alice signs the order
+      const signature = await alice.signTypedData({
+        domain: domainData,
+        types: orderType,
+        primaryType: "OrderComponents",
+        message: orderComponents,
+      });
+      const order = {
+        parameters: orderParameters,
+        signature: signature,
+      };
+
+      // construct advanced order
+      const advancedOrder = {
+        parameters: orderParameters,
+        numerator: wethTradeamount,
+        denominator: wethTradeamount,
+        signature: signature,
+        extraData: encodedLockParams,
+      };
+
+      // check that bob can swap
+      // check for expected starting balances
+      expect(await usdc.read.balanceOf([alice.account.address])).to.eq(
+        aliceStartingUsdcBalance
+      );
+      expect(await weth.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await weth.read.balanceOf([bob.account.address])).to.eq(
+        startingWethBalance
+      );
+      expect(await usdc.read.balanceOf([bob.account.address])).to.eq(0n);
+
+      // move forward in time
+      // go past when the plan would have fully vested to be sure that
+      // it starts when bob fills
+      await time.increase(2000);
+
+      // bob receives the signed order and fulfills it
+      await (
+        await getSeaport(bob)
+      ).write.fulfillAdvancedOrder([
+        advancedOrder,
+        [],
+        zeroHash,
+        bob.account.address,
+      ]);
+
+      // neither account should have any tokens
+      expect(await weth.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await usdc.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await usdc.read.balanceOf([bob.account.address])).to.eq(0n);
+      expect(await weth.read.balanceOf([bob.account.address])).to.eq(0n);
+
+      // check time lock contract balances for each
+      expect(await usdc.read.balanceOf([lockup.address])).to.eq(
+        usdcTradeAmount
+      );
+      expect(await weth.read.balanceOf([lockup.address])).to.eq(
+        wethTradeamount
+      );
+
+      // go forward in time so we're just before the cliff
+      await time.increase(80);
+
+      // each user retrieves their positions
+      await (await getLockup(alice)).write.redeemAllPlans();
+      await (await getLockup(bob)).write.redeemAllPlans();
+
+      // balances should still be 0
+      expect(await weth.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await usdc.read.balanceOf([bob.account.address])).to.eq(0n);
+
+      // go forward in time so we just reached the cliff
+      await time.increase(20);
+
+      // each user retrieves their positions
+      await (await getLockup(alice)).write.redeemAllPlans();
+      await (await getLockup(bob)).write.redeemAllPlans();
+
+      // balances should roughly be rate * cliff
+      expect(
+        Number(await weth.read.balanceOf([alice.account.address]))
+      ).to.greaterThan(Number(wethRate * cliff));
+      expect(
+        Number(await usdc.read.balanceOf([bob.account.address]))
+      ).to.greaterThan(Number(usdcRate * cliff));
+      expect(
+        Number(await weth.read.balanceOf([alice.account.address]))
+      ).to.lessThan(Number(wethTradeamount));
+      expect(
+        Number(await usdc.read.balanceOf([bob.account.address]))
+      ).to.lessThan(Number(usdcTradeAmount));
+
+      // go forward in time so the full amount is vested
+      await time.increase(1000);
+
+      // each user retrieves their positions
+      await (await getLockup(alice)).write.redeemAllPlans();
+      await (await getLockup(bob)).write.redeemAllPlans();
+
+      // check all balances
+      expect(await weth.read.balanceOf([alice.account.address])).to.eq(
+        wethTradeamount
+      );
+      expect(await usdc.read.balanceOf([alice.account.address])).to.eq(0n);
+      expect(await usdc.read.balanceOf([bob.account.address])).to.eq(
+        usdcTradeAmount
+      );
+      expect(await weth.read.balanceOf([bob.account.address])).to.eq(0n);
     });
   });
 });


### PR DESCRIPTION
A couple of changes:
1. add `initialized` to `CreatePlanParams`
     - used to check if params were supplied by user
     - really just improves readability
2. optional start time
     - this is a convenience feature, users will likely want the lockup to start when the order is filled, the time of which is unknown when they create the order
     - if `CreatePlanParams.start == 0`, use `block.timestamp`
     - also changed `CreatePlanParams.cliff` to `CreatePlanParams.cliffOffsetTime` so that the cliff is relative to the dynamic start time
     - cliffOffsetTime is the number of seconds after the start time that the cliff will start
3. dynamically calculate the `rate` param
     - this is a necessary change to support all types of seaport orders/fills
     - e.g. a partial fill will result in (offer/consideration).amount being smaller than the amount that the user might have used to initially calculate the rate, and that position would end up vesting faster than expected
     - so to fix, the user just supplies `CreatePlanParams.endOffsetTime` instead of `CreatePlanParams.rate`
     - endOffsetTime is the number of seconds after the start time that the plan will be fully vested
     - we then calculate `rate` as `(amount * period) / endOffsetTime`
